### PR TITLE
Add feo replacement flag

### DIFF
--- a/static/beta/prod/modules/fed-modules.json
+++ b/static/beta/prod/modules/fed-modules.json
@@ -728,6 +728,20 @@
             }
         ]
     },
+    "digitalRoadmap": {
+        "manifestLocation": "/apps/digital-roadmap/fed-mods.json",
+        "modules": [
+            {
+                "id": "digital-roadmap",
+                "module": "./RootApp",
+                "routes": [
+                    {
+                        "pathname": "/insights/digital-roadmap"
+                    }
+                ]
+            }
+        ]
+    },
     "malware": {
         "manifestLocation": "/apps/malware/fed-mods.json",
         "modules": [

--- a/static/beta/prod/navigation/rhel-navigation.json
+++ b/static/beta/prod/navigation/rhel-navigation.json
@@ -650,6 +650,17 @@
       "filterable": false,
       "href": "/insights/learning-resources",
       "product": "Red Hat Insights"
+    },
+    {
+      "id": "digitalRoadmap",
+      "appId": "digitalRoadmap",
+      "title": "Digital Roadmap",
+      "href": "/insights/digital-roadmap",
+      "product": "Red Hat Insights",
+      "description": "Tailored forward-looking roadmap information for RHEL customers, as well as tailored information on how current RHEL minor and major releases will affect the customers environment.",
+      "alt_title": [
+        "digital-roadmap"
+      ]
     }
   ]
 }

--- a/static/beta/stage/modules/fed-modules.json
+++ b/static/beta/stage/modules/fed-modules.json
@@ -916,6 +916,20 @@
             }
         ]
     },
+    "digitalRoadmap": {
+        "manifestLocation": "/apps/digital-roadmap/fed-mods.json",
+        "modules": [
+            {
+                "id": "digital-roadmap",
+                "module": "./RootApp",
+                "routes": [
+                    {
+                        "pathname": "/insights/digital-roadmap"
+                    }
+                ]
+            }
+        ]
+    },
     "dbaas": {
         "manifestLocation": "/apps/dbaas/fed-mods.json",
         "analytics": {

--- a/static/beta/stage/navigation/rhel-navigation.json
+++ b/static/beta/stage/navigation/rhel-navigation.json
@@ -665,6 +665,17 @@
       "filterable": false,
       "href": "/insights/learning-resources",
       "product": "Red Hat Insights"
+    },
+    {
+      "id": "digitalRoadmap",
+      "appId": "digitalRoadmap",
+      "title": "Digital Roadmap",
+      "href": "/insights/digital-roadmap",
+      "product": "Red Hat Insights",
+      "description": "Tailored forward-looking roadmap information for RHEL customers, as well as tailored information on how current RHEL minor and major releases will affect the customers environment.",
+      "alt_title": [
+        "digital-roadmap"
+      ]
     }
   ]
 }

--- a/static/stable/prod/modules/fed-modules.json
+++ b/static/stable/prod/modules/fed-modules.json
@@ -284,6 +284,20 @@
             }
         ]
     },
+    "digitalRoadmap": {
+        "manifestLocation": "/apps/digitalRoadmap/fed-mods.json",
+        "modules": [
+            {
+                "id": "digital-roadmap",
+                "module": "./RootApp",
+                "routes": [
+                    {
+                        "pathname": "/insights/digital-roadmap"
+                    }
+                ]
+            }
+        ]
+    },
     "ocpAdvisor": {
         "manifestLocation": "/apps/ocp-advisor/fed-mods.json",
         "modules": [

--- a/static/stable/prod/navigation/insights-navigation.json
+++ b/static/stable/prod/navigation/insights-navigation.json
@@ -670,6 +670,17 @@
       "filterable": false,
       "href": "/insights/learning-resources",
       "product": "Red Hat Insights"
+    },
+    {
+      "id": "digitalRoadmap",
+      "appId": "digitalRoadmap",
+      "title": "Digital Roadmap",
+      "href": "/insights/digital-roadmap",
+      "product": "Red Hat Insights",
+      "description": "Tailored forward-looking roadmap information for RHEL customers, as well as tailored information on how current RHEL minor and major releases will affect the customers environment.",
+      "alt_title": [
+        "digital-roadmap"
+      ]
     }
   ]
 }

--- a/static/stable/stage/modules/fed-modules.json
+++ b/static/stable/stage/modules/fed-modules.json
@@ -895,6 +895,20 @@
           }
       ]
   },
+  "digitalRoadmap": {
+    "manifestLocation": "/apps/digital-roadmap/fed-mods.json",
+    "modules": [
+        {
+            "id": "digital-roadmap",
+            "module": "./RootApp",
+            "routes": [
+                {
+                    "pathname": "/insights/digital-roadmap"
+                }
+            ]
+        }
+    ]
+},
   "dbaas": {
       "manifestLocation": "/apps/dbaas/fed-mods.json",
       "analytics": {

--- a/static/stable/stage/navigation/insights-navigation.json
+++ b/static/stable/stage/navigation/insights-navigation.json
@@ -610,6 +610,17 @@
       "filterable": false,
       "href": "/insights/learning-resources",
       "product": "Red Hat Insights"
+    },
+    {
+      "id": "digitalRoadmap",
+      "appId": "digitalRoadmap",
+      "title": "Digital Roadmap",
+      "href": "/insights/digital-roadmap",
+      "product": "Red Hat Insights",
+      "description": "Tailored forward-looking roadmap information for RHEL customers, as well as tailored information on how current RHEL minor and major releases will affect the customers environment.",
+      "alt_title": [
+        "digital-roadmap"
+      ]
     }
   ]
 }

--- a/static/stable/stage/navigation/insights-navigation.json
+++ b/static/stable/stage/navigation/insights-navigation.json
@@ -620,7 +620,8 @@
       "description": "Tailored forward-looking roadmap information for RHEL customers, as well as tailored information on how current RHEL minor and major releases will affect the customers environment.",
       "alt_title": [
         "digital-roadmap"
-      ]
+      ],
+      "feoReplacement": "planning"
     }
   ]
 }


### PR DESCRIPTION
This PR adds the feoReplacement flag for the migration from chrome-service to the frontend repository. The flag will allow for the bundle segment in the frontend.yaml of the frontend repository to be used for the navigation.
Documentation - https://github.com/RedHatInsights/chrome-service-backend/blob/main/docs/feo-migration-guide.md#4-mark-the-navigation-items-for-replacement-chrome-service-backend-repository